### PR TITLE
Add 1.0.0's MultiMC Instance

### DIFF
--- a/multimc.html
+++ b/multimc.html
@@ -26,6 +26,12 @@
                 <td>Versions:</td>
             </tr>
 			<tr>
+				<td>1.0.0 </td>
+				<td>
+					<a href="https://github.com/calmilamsy/Cursed-Fabric-MultiMC/archive/4ac716637a333c38035d420a029f769cfbf861c5.zip">download</a>
+				</td>
+			</tr>
+			<tr>
 				<td>0.10.6:cfb4298 hotfix</td>
 				<td>
 					<a href="https://github.com/calmilamsy/Cursed-Fabric-MultiMC/archive/299d73287a079b6d1161a74abe37f0710bee888c.zip">download</a>


### PR DESCRIPTION
A few months late, but better late than never.

Also the loader jar gets downloaded instead of being shipped with the instance.